### PR TITLE
fix the data bug for few-shot experiment

### DIFF
--- a/datasets/few_shot_dataset.py
+++ b/datasets/few_shot_dataset.py
@@ -72,7 +72,7 @@ class SetDataset:
             train_dataset = get_dataset(dset, root, 'train', transform)
             valid_dataset = get_dataset(dset, root, 'val', transform)
             trainval_dataset = ConcatDataset([train_dataset, valid_dataset])
-        if dset in [datasets.CIFAR10, datasets.CIFAR100]:
+        elif dset in [datasets.CIFAR10, datasets.CIFAR100]:
             trainval_dataset = get_dataset(dset, root, 'train', identity)
         else:
             trainval_dataset = get_dataset(dset, root, 'train', transform)


### PR DESCRIPTION
Currently,  I find when testing the “few-shot exp” on Flowers dataset, there is something wrong with the dataloader (“RuntimeError: stack expects each tensor to be equal size, but got [35, 3, 32, 32] at entry 0 and [33, 3, 32, 32] at entry 1”).

And I found reason is: https://github.com/linusericsson/ssl-transfer/blob/main/datasets/few_shot_dataset.py#L75
It should be 'elif' rather than 'if'.
And I have also tested it after revising. The results are same with paper report.